### PR TITLE
Added the feature to import particles from user-defined hdf5 files

### DIFF
--- a/source/sim_beams_class.f03
+++ b/source/sim_beams_class.f03
@@ -121,21 +121,24 @@ subroutine init_sim_beams( this, input, opts )
 
     call input%get( 'beam('//num2str(i)//').profile', npf )
     select case ( npf )
-    case (0)
-       allocate( fdist3d_000 :: this%pf(i)%p )
-       call this%pf(i)%p%new( input, i )
-    case (1)
-       allocate( fdist3d_001 :: this%pf(i)%p )
-       call this%pf(i)%p%new( input, i )
-    case (2)
-       allocate( fdist3d_002 :: this%pf(i)%p )
-       call this%pf(i)%p%new( input, i )
-    case (100)
-       allocate( fdist3d_100 :: this%pf(i)%p )
-       call this%pf(i)%p%new( input, i )
+      case (0)
+        allocate( fdist3d_000 :: this%pf(i)%p )
+        call this%pf(i)%p%new( input, i )
+      case (1)
+        allocate( fdist3d_001 :: this%pf(i)%p )
+        call this%pf(i)%p%new( input, i )
+      case (2)
+        allocate( fdist3d_002 :: this%pf(i)%p )
+        call this%pf(i)%p%new( input, i )
+      case (100)
+        allocate( fdist3d_100 :: this%pf(i)%p )
+        call this%pf(i)%p%new( input, i )
+      case (101)
+        allocate( fdist3d_101 :: this%pf(i)%p )
+        call this%pf(i)%p%new( input, i )
   ! Add new distributions right above this line
-    case default
-      call write_err( 'Invalid beam profile!' )
+      case default
+        call write_err( 'Invalid beam profile!' )
     end select
 
   enddo


### PR DESCRIPTION
Added the feature to import particles from user-defined hdf5 files.

New input file parameters include:

- `filename`: the name of the hdf5 file to be read.
- `center`: the center of the imported beam (in the QPAD simulation unit). The three components are x, y, and xi respectively.
- `file_center`: the center of the imported beam (in the user-specified unit). The three components are x, y, and z respectively.
- `xconv_fac`: the unit converting factor for the beam center.
- `qconv_fac`: the particle charge scaling factor. Each particle read by QPAD will be multiplied by this factor.