### PR TITLE
Fixed a bug in the profile 2 (piecewise linear) initialization of beam particles

### DIFF
--- a/source/beam/fdist3d_class.f03
+++ b/source/beam/fdist3d_class.f03
@@ -766,7 +766,7 @@ subroutine init_fdist3d_002(this,input,i)
       endif
       sumz = sumz + (this%fz(ii) + this%fz(ii-1)) * (this%z(ii) - this%z(ii-1)) * 0.5
    end do
-   this%z = this%z/dz
+   this%z = (this%z - this%z0) / dz
    this%npf = npf
    this%dx = dr
    this%dz = dz

--- a/source/beam/fdist3d_lib.f03
+++ b/source/beam/fdist3d_lib.f03
@@ -293,7 +293,6 @@ subroutine beam_dist002(x,p,q,qm,edges,npp,dr,dz,nps,vtx,vty,vtz,vdx,&
       enddo
       tempz = ( real(j-1) + (tag - zf(j-1)) / (zf(j) - zf(j-1)) ) * dz + zmin
 
-
       tempxx = -cx(1)*(tempz-z0)**2-cx(2)*(tempz-z0)-cx(3)
       tempyy = -cy(1)*(tempz-z0)**2-cy(2)*(tempz-z0)-cy(3)
       do


### PR DESCRIPTION
The old version initialized the beam particles at the wrong longitudinal position if the piecewise linear distribution (profile 2) is used.  It only worked normally when the lower boundary in z was set 0. Now this bug has been fixed.