### PR TITLE
Add check to avoid 0/0 division in fpcr_penta solver

### DIFF
--- a/source/pcr-fortran/fpcr_penta_class.f03
+++ b/source/pcr-fortran/fpcr_penta_class.f03
@@ -475,7 +475,7 @@ subroutine generate_cr_coef_fpcr_penta( this )
       tmp = am1*cp1*dm2*dp2 - am1*bp2*dm2*ep1 + ap1*bm2*dp2*em1 + bm2*bp2*cm1*ep1 - bm2*cm1*cp1*dp2
       ! print *, "    tmp = ", tmp
 
-      if( abs(tmp) > epsilon(1.0) ) then 
+      if( abs(tmp) > 1e-40 ) then
          tmp = 1.0 / tmp
          this%coefm2(i, step) =  am1 * ( ap1*d0*dp2 + b0*bp2*ep1 - b0*cp1*dp2 ) * tmp
          this%coefm1(i, step) = -bm2 * ( ap1*d0*dp2 + b0*bp2*ep1 - b0*cp1*dp2 ) * tmp


### PR DESCRIPTION
In my runs where `rmax` and `nr` are very large, there seems to be numerical instability for calculation of the laser solver coefficients. The a, b, d, and e solver values approach zero which results in a 0/0 division and manifests as nans (at least with gcc on Perlmutter).

This fix addresses the issue. It's a bit ad-hoc and there may be a better solution to avoid this numerical instability, but nothing was immediately obvious to me. 

Attached is an example of a deck where the laser field becomes all nan after the first timestep without this fix. The laser field solution looks as it should at t=20 (at the focal point) with the fix. The run does not crash with the old version if `nr` is set to 64 without changing `rmax`. (The simulation is no longer resolved, though.)


[qpinput.json](https://github.com/UCLA-Plasma-Simulation-Group/QPAD/files/12962474/qpinput.json)
