### PR TITLE
Change t to z in the input and laser initialization, fix LG pulse initialization, and adjust chirp behavior

### DIFF
--- a/docs/source/input_file/session_laser.rst
+++ b/docs/source/input_file/session_laser.rst
@@ -97,7 +97,7 @@ The "lasers" is an array and each component is a session defines the parameters 
     Center of laser pulse in :math:`\xi`-direction. 
 
 *  ``chirp_coefs``, real array (*), optional
-    Frequency chirp coefficients :math:`C` of laser pulse. The frequency chirp distribution is described by :math:`k(\xi)=k_0+C(1)(\xi-\xi_0)+C(2)(\xi-\xi_0)^2+...` where :math:`k_0` and :math:`\xi_0` are the central wavenumber and longitudinal center defined by ``k0`` and ``lon_center`` respectively. The default is [0.0].
+    Frequency chirp coefficients :math:`C` of laser pulse. The frequency chirp distribution is described by :math:`k(\xi)=k_0+C(1)+C(2)(\xi-\xi_0)+C(3)(\xi-\xi_0)^2+...` where :math:`k_0` and :math:`\xi_0` are the central wavenumber and longitudinal center defined by ``k0`` and ``lon_center`` respectively. The default is [0.0]. Note that the first coefficient allows for a uniform offset in wavenumber from ``k0``.
 
 * ``diag``, session array(\*), optional
     For lasers, every type of diagnostics must be provided as a session. The parameters of each session include

--- a/docs/source/input_file/session_laser.rst
+++ b/docs/source/input_file/session_laser.rst
@@ -18,6 +18,8 @@ The "lasers" is an array and each component is a session defines the parameters 
         Radius (:math:`1/e^2`) of laser pulse.
     * ``focal_distance``, real
         Distance of focal plane from the laser pulse. If negative, the focal plane is behind the laser pulse.
+    * ``phase``, real, optional
+        Constant phase offset (in degrees) to apply to the pulse. Defaults to zero, and has the same sign as the curvature term, i.e., exp(-i * phase) under the current convention.
 
     The ``"laguerre"`` defines a Laguerre-Gaussian laser pulse, and the following characteristic parameters need to be provided
 

--- a/docs/source/input_file/session_simulation.rst
+++ b/docs/source/input_file/session_simulation.rst
@@ -11,11 +11,11 @@ Simulation Session
     The first and second components define the number of cells used along r- and :math:`\xi`-direction respectively.
 
 * ``box``, session
-    Define the size of simulation box in r- and :math:`\xi`-direction. This session includes two parameters
+    Define the size of simulation box in `r`- and :math:`\xi`-direction. This session includes two parameters
 
     * ``r``, real array(2)
-        Starting and end coordinates in r-direction. The lower limit should be always 0.
-    * ``z``, real array(2)
+        Starting and end coordinates in `r`-direction. The lower limit should be always 0.
+    * ``xi``, real array(2)
         Starting and end coordinates in :math:`\xi`-direction.
 
 * ``field_boundary``, string
@@ -30,11 +30,11 @@ Simulation Session
 * ``n0``, real
     Reference plasma density (in the unit of :math:`\text{cm}^{-3}`). **This parameter is required when the ionization is turned on**.
 
-* ``time``, real
-    Total duration of the simulation. The initial moment defaults to 0.
+* ``length``, real
+    Total length of the simulation (in `z`). The initial value defaults to 0.
 
-* ``dt``, real
-    Time step of pushing relativistic particle beams.
+* ``dz``, real
+    Spatial step of pushing relativistic particle beams.
 
 * ``nbeams``, integer
     Total number of particle beams.

--- a/source/beam/fdist3d_file_class.f03
+++ b/source/beam/fdist3d_file_class.f03
@@ -79,7 +79,7 @@ subroutine init_fdist3d_file( this, input, opts, sect_id )
   sect_name = 'beam(' // num2str(sect_id) // ')'
 
   call input%get( trim(sect_name) // '.filename', this%filename )
-  call input%get( 'simulation.box.z(1)', this%z0 )
+  call input%get( 'simulation.box.xi(1)', this%z0 )
   call input%get( trim(sect_name) // '.beam_center(1)', this%beam_ctr(1) )
   call input%get( trim(sect_name) // '.beam_center(2)', this%beam_ctr(2) )
   call input%get( trim(sect_name) // '.beam_center(3)', this%beam_ctr(3) )

--- a/source/beam/fdist3d_rnd_class.f03
+++ b/source/beam/fdist3d_rnd_class.f03
@@ -231,7 +231,7 @@ subroutine init_fdist3d_rnd( this, input, opts, sect_id )
   call this%set_prof2( input, trim(sect_name), 2, this%prof_pars2 )
   call this%set_prof3( input, trim(sect_name), 3, this%prof_pars3 )
 
-  call input%get( 'simulation.box.z(1)', this%z0 )
+  call input%get( 'simulation.box.xi(1)', this%z0 )
   call input%get( trim(sect_name) // '.total_num', this%tot_num )
   call input%get( trim(sect_name) // '.total_charge', this%tot_charge )
   call input%get( trim(sect_name) // '.q', this%qm )

--- a/source/beam/fdist3d_rnd_lib.f03
+++ b/source/beam/fdist3d_rnd_lib.f03
@@ -37,7 +37,7 @@ subroutine set_prof_uniform( input, sect_name, dim, prof_pars )
   call input%get( trim(sect_name) // '.range' // num2str(dim) // '(1)', prof_pars(1) )
   call input%get( trim(sect_name) // '.range' // num2str(dim) // '(2)', prof_pars(2) )
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
     prof_pars(2) = prof_pars(2) - z0
   endif
@@ -79,7 +79,7 @@ subroutine set_prof_gaussian( input, sect_name, dim, prof_pars )
   call input%get( trim(sect_name) // '.gauss_center(' // num2str(dim) // ')', prof_pars(1) )
   call input%get( trim(sect_name) // '.gauss_sigma(' // num2str(dim) // ')', prof_pars(2) )
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -123,7 +123,7 @@ subroutine set_prof_super_gauss( input, sect_name, dim, prof_pars )
     call write_err("The order of super-Gaussian profile must be >= 1.")
   endif
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -164,7 +164,7 @@ subroutine set_prof_parabolic( input, sect_name, dim, prof_pars )
   call input%get( trim(sect_name) // '.parabolic_center(' // num2str(dim) // ')', prof_pars(1) )
   call input%get( trim(sect_name) // '.parabolic_radius(' // num2str(dim) // ')', prof_pars(2) )
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -235,7 +235,7 @@ subroutine set_prof_pw_linear( input, sect_name, dim, prof_pars )
   enddo
 
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1:len_x) = prof_pars(1:len_x) - z0
   endif
 

--- a/source/beam/fdist3d_std_class.f03
+++ b/source/beam/fdist3d_std_class.f03
@@ -304,7 +304,7 @@ subroutine init_fdist3d_std( this, input, opts, sect_id )
     call this%set_prof3( input, trim(sect_name), 3, this%prof_pars3 )
   endif
 
-  call input%get( 'simulation.box.z(1)', this%z0 )
+  call input%get( 'simulation.box.xi(1)', this%z0 )
   call input%get( trim(sect_name) // '.ppc(1)', this%ppc(1) )
   call input%get( trim(sect_name) // '.ppc(2)', this%ppc(2) )
   call input%get( trim(sect_name) // '.ppc(3)', this%ppc(3) )

--- a/source/beam/fdist3d_std_lib.f03
+++ b/source/beam/fdist3d_std_lib.f03
@@ -61,7 +61,7 @@ subroutine set_prof_analytic( input, sect_name, prof_pars, math_func )
 
   allocate( prof_pars(1) )
 
-  call input%get( 'simulation.box.z(1)', z0 )
+  call input%get( 'simulation.box.xi(1)', z0 )
   prof_pars(1) = - z0
 
   call input%get( trim(sect_name) // '.math_func', read_str )
@@ -105,7 +105,7 @@ subroutine set_prof_gaussian( input, sect_name, dim, prof_pars )
   call input%get( trim(sect_name) // '.gauss_center(' // num2str(dim) // ')', prof_pars(1) )
   call input%get( trim(sect_name) // '.gauss_sigma(' // num2str(dim) // ')', prof_pars(2) )
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -151,7 +151,7 @@ subroutine set_prof_super_gauss( input, sect_name, dim, prof_pars )
     call write_err("The order of super-Gaussian profile must be >= 1.")
   endif
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -194,7 +194,7 @@ subroutine set_prof_parabolic( input, sect_name, dim, prof_pars )
   call input%get( trim(sect_name) // '.parabolic_center(' // num2str(dim) // ')', prof_pars(1) )
   call input%get( trim(sect_name) // '.parabolic_radius(' // num2str(dim) // ')', prof_pars(2) )
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -249,7 +249,7 @@ subroutine set_prof_rational( input, sect_name, dim, prof_pars )
   prof_pars(4:len_pn+3) = pn
   prof_pars(len_pn+4:len_pn+len_pd+3) = pd
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1) = prof_pars(1) - z0
   endif
 
@@ -321,7 +321,7 @@ subroutine set_prof_pw_linear( input, sect_name, dim, prof_pars )
     prof_pars(len_x+i) = fx(i)
   enddo
   if ( dim == 3 ) then
-    call input%get( 'simulation.box.z(1)', z0 )
+    call input%get( 'simulation.box.xi(1)', z0 )
     prof_pars(1:len_x) = prof_pars(1:len_x) - z0
   endif
 

--- a/source/diagnostics_class.f03
+++ b/source/diagnostics_class.f03
@@ -188,9 +188,9 @@ subroutine init_diag_beams( this, input, beams )
 
   call input%get( 'simulation.box.r(1)', rmin )
   call input%get( 'simulation.box.r(2)', rmax )
-  call input%get( 'simulation.box.z(1)', zmin )
-  call input%get( 'simulation.box.z(2)', zmax )
-  call input%get( 'simulation.dt', dt )
+  call input%get( 'simulation.box.xi(1)', zmin )
+  call input%get( 'simulation.box.xi(2)', zmax )
+  call input%get( 'simulation.dz', dt )
 
   ! add beam diagnostics
   do i = 1, nbeams
@@ -264,9 +264,9 @@ subroutine init_diag_plasma( this, input, plasma )
   call input%get( 'simulation.nneutrals', nneutrals )
   call input%get( 'simulation.box.r(1)', rmin )
   call input%get( 'simulation.box.r(2)', rmax )
-  call input%get( 'simulation.box.z(1)', zmin )
-  call input%get( 'simulation.box.z(2)', zmax )
-  call input%get( 'simulation.dt', dt )
+  call input%get( 'simulation.box.xi(1)', zmin )
+  call input%get( 'simulation.box.xi(2)', zmax )
+  call input%get( 'simulation.dz', dt )
 
   ! add species diagnostics
   do i = 1, nspecies
@@ -409,9 +409,9 @@ subroutine init_diag_fields( this, input, opts, fields )
   call input%get( 'simulation.max_mode', max_mode )
   call input%get( 'simulation.box.r(1)', rmin )
   call input%get( 'simulation.box.r(2)', rmax )
-  call input%get( 'simulation.box.z(1)', zmin )
-  call input%get( 'simulation.box.z(2)', zmax )
-  call input%get( 'simulation.dt', dt )
+  call input%get( 'simulation.box.xi(1)', zmin )
+  call input%get( 'simulation.box.xi(2)', zmax )
+  call input%get( 'simulation.dz', dt )
 
   call input%info( 'field.diag', n_children=m )
   do j = 1, m
@@ -621,9 +621,9 @@ subroutine init_diag_lasers( this, input, opts, lasers )
   call input%get( 'simulation.max_mode', max_mode )
   call input%get( 'simulation.box.r(1)', rmin )
   call input%get( 'simulation.box.r(2)', rmax )
-  call input%get( 'simulation.box.z(1)', zmin )
-  call input%get( 'simulation.box.z(2)', zmax )
-  call input%get( 'simulation.dt', dt )
+  call input%get( 'simulation.box.xi(1)', zmin )
+  call input%get( 'simulation.box.xi(2)', zmax )
+  call input%get( 'simulation.dz', dt )
   call input%get( 'simulation.nlasers', nlasers )
 
   do i = 1, nlasers

--- a/source/fields/field_class.f03
+++ b/source/fields/field_class.f03
@@ -80,10 +80,10 @@ type :: field
   procedure, private :: pipe_send_f1, pipe_recv_f1
   procedure, private :: pipe_send_f2, pipe_recv_f2
 
-  generic :: assignment(=) => assign_f1
-  generic :: as            => assign_f2
+  generic :: assignment(=) => assign_f1_real, assign_f1_field
+  generic :: as            => assign_f2_real, assign_f2_field
 
-  procedure, private :: assign_f1, assign_f2
+  procedure, private :: assign_f1_real, assign_f1_field, assign_f2_real, assign_f2_field
 
 end type field
 
@@ -914,75 +914,73 @@ function get_rf_im_mode( this, mode )
 
 end function get_rf_im_mode
 
-subroutine assign_f1( this, that )
+subroutine assign_f1_real( this, that )
 
   implicit none
 
   class( field ), intent(inout) :: this
-  class(*), intent(in) :: that
+  real, intent(in) :: that
 
   integer :: i
 
-  select type (that)
+  do i = 0, this%max_mode
+    this%rf_re(i) = that
+    if (i == 0) cycle
+    this%rf_im(i) = that
+  enddo
 
-  type is (real)
+end subroutine assign_f1_real
 
-    do i = 0, this%max_mode
-      this%rf_re(i) = that
-      if (i == 0) cycle
-      this%rf_im(i) = that
-    enddo
-
-  class is (field)
-
-    do i = 0, this%max_mode
-      this%rf_re(i) = that%rf_re(i)
-      if (i == 0) cycle
-      this%rf_im(i) = that%rf_im(i)
-    enddo
-
-  class default
-
-    call write_err( "invalid assignment type!" )
-
-  end select
-
-end subroutine assign_f1
-
-subroutine assign_f2( this, that )
+subroutine assign_f1_field( this, that )
 
   implicit none
 
   class( field ), intent(inout) :: this
-  class(*), intent(in) :: that
+  class( field ), intent(in) :: that
 
   integer :: i
 
-  select type (that)
+  do i = 0, this%max_mode
+    this%rf_re(i) = that%rf_re(i)
+    if (i == 0) cycle
+    this%rf_im(i) = that%rf_im(i)
+  enddo
 
-  type is (real)
+end subroutine assign_f1_field
 
-    do i = 0, this%max_mode
-      call this%rf_re(i)%as( that )
-      if (i == 0) cycle
-      call this%rf_im(i)%as( that )
-    enddo
+subroutine assign_f2_real( this, that )
 
-  class is (field)
+  implicit none
 
-    do i = 0, this%max_mode
-      call this%rf_re(i)%as( that%get_rf_re(i) )
-      if (i == 0) cycle
-      call this%rf_im(i)%as( that%get_rf_im(i) )
-    enddo
+  class( field ), intent(inout) :: this
+  real, intent(in) :: that
 
-  class default
+  integer :: i
 
-    call write_err( "invalid assignment type!" )
+  do i = 0, this%max_mode
+    call this%rf_re(i)%as( that )
+    if (i == 0) cycle
+    call this%rf_im(i)%as( that )
+  enddo
 
-  end select
+end subroutine assign_f2_real
 
-end subroutine assign_f2
+subroutine assign_f2_field( this, that )
+
+  implicit none
+
+  class( field ), intent(inout) :: this
+  class( field ), intent(in) :: that
+
+  integer :: i
+
+  do i = 0, this%max_mode
+    call this%rf_re(i)%as( that%get_rf_re(i) )
+    if (i == 0) cycle
+    call this%rf_im(i)%as( that%get_rf_im(i) )
+  enddo
+
+end subroutine assign_f2_field
 
 subroutine add_f1_binary_dim( a1, a2, a3, dim1, dim2, dim3 )
 

--- a/source/fields/ufield_class.f03
+++ b/source/fields/ufield_class.f03
@@ -84,8 +84,8 @@ type :: ufield
   procedure :: read_hdf5
   procedure :: smooth_f1
 
-  generic :: assignment(=)   => assign_f1
-  generic :: as              => assign_f2
+  generic :: assignment(=)   => assign_f1_real, assign_f1_ufield
+  generic :: as              => assign_f2_real, assign_f2_ufield
 
   procedure, private :: init_ufield, init_ufield_cp, end_ufield
   procedure, private :: get_nd_all, get_nd_dim
@@ -93,7 +93,7 @@ type :: ufield
   procedure, private :: get_gc_num_all, get_gc_num_dim
   procedure, private :: get_noff_all, get_noff_dim
   procedure, private :: write_hdf5_single, write_hdf5_pipe
-  procedure, private :: assign_f1, assign_f2
+  procedure, private :: assign_f1_real, assign_f1_ufield, assign_f2_real, assign_f2_ufield
 
 end type ufield
 
@@ -728,63 +728,57 @@ subroutine acopy_gc_f2( this )
 
 end subroutine acopy_gc_f2
 
-subroutine assign_f1( this, that )
+subroutine assign_f1_real( this, that )
 
   implicit none
 
   class( ufield ), intent(inout) :: this
-  class(*), intent(in) :: that
+  real, intent(in) :: that
 
-  select type (that)
+  this%f1 = that
 
-    type is (real)
+end subroutine assign_f1_real
 
-      this%f1 = that
-
-    class is (ufield)
-
-      if ( all( this%gc_num(:,1)==that%gc_num(:,1) ) ) then
-        this%f1 = that%f1
-      else
-        call write_err( "guard cells not matched!" )
-      endif
-
-    class default
-
-      call write_err( "invalid assignment type!" )
-
-  end select
-
-end subroutine assign_f1
-
-subroutine assign_f2( this, that )
+subroutine assign_f1_ufield( this, that )
 
   implicit none
 
   class( ufield ), intent(inout) :: this
-  class(*), intent(in) :: that
+  class( ufield ), intent(in) :: that
 
-  select type (that)
+  if ( all( this%gc_num(:,1)==that%gc_num(:,1) ) ) then
+    this%f1 = that%f1
+  else
+    call write_err( "guard cells not matched!" )
+  endif
 
-    type is (real)
+end subroutine assign_f1_ufield
 
-      this%f2 = that
+subroutine assign_f2_real( this, that )
 
-    class is (ufield)
+  implicit none
 
-      if ( all( this%gc_num==that%gc_num ) ) then
-        this%f2 = that%f2
-      else
-        call write_err( "guard cells not matched!" )
-      endif
+  class( ufield ), intent(inout) :: this
+  real, intent(in) :: that
 
-    class default
+  this%f2 = that
 
-      call write_err( "invalid assignment type!" )
+end subroutine assign_f2_real
 
-  end select
+subroutine assign_f2_ufield( this, that )
 
-end subroutine assign_f2
+  implicit none
+
+  class( ufield ), intent(inout) :: this
+  class( ufield ), intent(in) :: that
+
+  if ( all( this%gc_num==that%gc_num ) ) then
+    this%f2 = that%f2
+  else
+    call write_err( "guard cells not matched!" )
+  endif
+
+end subroutine assign_f2_ufield
 
 subroutine add_f1_binary_dim( a1, a2, a3, dim1, dim2, dim3 )
 

--- a/source/laser/profile_laser_class.f03
+++ b/source/laser/profile_laser_class.f03
@@ -278,7 +278,7 @@ subroutine init_profile_laser( this, input, opts, sect_id )
   endif
 
   call input%get( trim(sect_name) // '.k0', this%k0 )
-  call input%get( 'simulation.box.z(1)', this%z0 )
+  call input%get( 'simulation.box.xi(1)', this%z0 )
 
   this%chirp_coefs = [0.0]
   if ( input%found( trim(sect_name) // '.chirp_coefs' ) ) then

--- a/source/laser/profile_laser_class.f03
+++ b/source/laser/profile_laser_class.f03
@@ -340,7 +340,7 @@ subroutine launch_profile_laser( this, ar_re, ar_im, ai_re, ai_im )
       ! longitudinal frequency chirp
       k = this%k0
       do l = 1, size(this%chirp_coefs)
-        k = k + this%chirp_coefs(l) * z ** l
+        k = k + this%chirp_coefs(l) * z ** (l - 1)
       enddo
 
       do i = 1, this%nrp

--- a/source/laser/profile_laser_class.f03
+++ b/source/laser/profile_laser_class.f03
@@ -76,10 +76,10 @@ type, public :: profile_laser
 end type profile_laser
 
 interface
-  subroutine get_prof_perp_intf( r, z, k, k0, prof_pars, mode, ar_re, ar_im, ai_re, ai_im )
+  subroutine get_prof_perp_intf( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im, ai_re, ai_im )
     import kw_list
     implicit none
-    real, intent(in) :: r, z, k, k0
+    real, intent(in) :: r, z, t, k, k0
     type(kw_list), intent(in) :: prof_pars
     integer, intent(in) :: mode
     real, intent(out) :: ar_re, ar_im, ai_re, ai_im
@@ -352,7 +352,7 @@ subroutine launch_profile_laser( this, ar_re, ar_im, ai_re, ai_im )
            call this%get_prof_perp_astrl( r, z, t, k, this%k0, &
                 this%prof_perp_pars, this%math_funcs, m, arr, ari, air, aii )           
         else
-           call this%get_prof_perp( r, z, k, this%k0, this%prof_perp_pars, m, arr, ari, air, aii )
+           call this%get_prof_perp( r, z, t, k, this%k0, this%prof_perp_pars, m, arr, ari, air, aii )
         endif
 
         if ( this%prof_type(2) == p_prof_laser_pw_linear ) then

--- a/source/laser/profile_laser_class.f03
+++ b/source/laser/profile_laser_class.f03
@@ -328,19 +328,19 @@ subroutine launch_profile_laser( this, ar_re, ar_im, ai_re, ai_im )
   
   call write_dbg( cls_name, sname, cls_level, 'starts' )
 
-  ! launch occurs at t=0 
-  t = 0.0 
+  ! launch occurs at z=0 
+  z = 0
 
   max_mode = size(ar_im)
   do m = 0, max_mode
     do j = 1, this%nzp
-      ! note that here "z" refers to xi = t - z
-      z = ( this%noff_z + j - 1 ) * this%dz + this%z0 - this%lon_center
+      ! note that here "t" refers to xi = t - z
+      t = ( this%noff_z + j - 1 ) * this%dz + this%z0 - this%lon_center
 
       ! longitudinal frequency chirp
       k = this%k0
       do l = 1, size(this%chirp_coefs)
-        k = k + this%chirp_coefs(l) * z ** (l - 1)
+        k = k + this%chirp_coefs(l) * t ** (l - 1)
       enddo
 
       do i = 1, this%nrp
@@ -356,11 +356,11 @@ subroutine launch_profile_laser( this, ar_re, ar_im, ai_re, ai_im )
         endif
 
         if ( this%prof_type(2) == p_prof_laser_pw_linear ) then
-          call this%get_prof_lon_lin( z, this%prof_lon_pars_lin, env )
+          call this%get_prof_lon_lin( t, this%prof_lon_pars_lin, env )
         else if ( this%prof_type(2) ==  p_prof_laser_cubic_spline ) then 
-          call this%get_prof_lon_cub( z, this%prof_lon_pars_cub, env )
+          call this%get_prof_lon_cub( t, this%prof_lon_pars_cub, env )
         else 
-          call this%get_prof_lon( z, this%prof_lon_pars, env )
+          call this%get_prof_lon( t, this%prof_lon_pars, env )
        endif
         
         env = env * this%a0

--- a/source/laser/profile_laser_lib.f03
+++ b/source/laser/profile_laser_lib.f03
@@ -338,7 +338,7 @@ subroutine normalize_a0_astrl_discrete( r_norm, xi_norm, z_norm, &
   ! longitudinal frequency chirp
   k = k0
   do l = 1, size(chirp_coefs)
-     k = k + chirp_coefs(l) * xi_norm ** l
+     k = k + chirp_coefs(l) * xi_norm ** (l - 1)
   enddo
   
   call get_prof_perp_astrl_discrete( r_norm, xi_norm, z_norm, k, k0, prof_pars, math_funcs, &

--- a/source/laser/profile_laser_lib.f03
+++ b/source/laser/profile_laser_lib.f03
@@ -53,10 +53,10 @@ subroutine set_prof_perp_gaussian( input, sect_name, prof_pars )
 
 end subroutine set_prof_perp_gaussian
 
-subroutine get_prof_perp_gaussian( r, z, k, k0, prof_pars, mode, ar_re, ar_im, ai_re, ai_im )
+subroutine get_prof_perp_gaussian( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im, ai_re, ai_im )
 
   implicit none
-  real, intent(in) :: r, z, k, k0
+  real, intent(in) :: r, z, t, k, k0
   type(kw_list), intent(in) :: prof_pars
   integer, intent(in) :: mode
   real, intent(out) :: ar_re, ar_im, ai_re, ai_im
@@ -76,7 +76,7 @@ subroutine get_prof_perp_gaussian( r, z, k, k0, prof_pars, mode, ar_re, ar_im, a
     curv = z_shift / ( z2 + zr2 )
     w = w0 * sqrt( 1.0 + z2 / zr2 )
     gouy_shift = atan2( z_shift, zr )
-    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * z
+    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * t
     amp = w0 / w * exp(-r2 / (w*w))
 
     ar_re = amp * cos(phase)
@@ -119,10 +119,10 @@ subroutine set_prof_perp_laguerre( input, sect_name, prof_pars )
 
 end subroutine set_prof_perp_laguerre
 
-subroutine get_prof_perp_laguerre( r, z, k, k0, prof_pars, mode, ar_re, ar_im, ai_re, ai_im )
+subroutine get_prof_perp_laguerre( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im, ai_re, ai_im )
 
   implicit none
-  real, intent(in) :: r, z, k, k0
+  real, intent(in) :: r, z, t, k, k0
   type(kw_list), intent(in) :: prof_pars
   integer, intent(in) :: mode
   real, intent(out) :: ar_re, ar_im, ai_re, ai_im
@@ -147,7 +147,7 @@ subroutine get_prof_perp_laguerre( r, z, k, k0, prof_pars, mode, ar_re, ar_im, a
     w2 = w0 * w0 * ( 1.0 + z2 / zr2 )
     r2_iw2 = r2 / w2
     gouy_shift = real( 1 + 2 * p + abs(l) ) * atan2( z_shift, zr )
-    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * z
+    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * t
 
     ! This is the definition from Wikipedia
     ! amp = w0 / sqrt(w2) * exp(-r2_iw2) * ( sqrt2 * sqrt(r2_iw2) ) ** abs(l) &

--- a/source/laser/profile_laser_lib.f03
+++ b/source/laser/profile_laser_lib.f03
@@ -50,6 +50,12 @@ subroutine set_prof_perp_gaussian( input, sect_name, prof_pars )
   call prof_pars%append( 'w0', val )
   call input%get( trim(sect_name) // '.focal_distance', val )
   call prof_pars%append( 'f_dist', val )
+  if ( input%found( trim(sect_name) // '.phase' ) ) then
+    call input%get( trim(sect_name) // '.phase', val )
+  else
+    val = 0.0
+  endif
+  call prof_pars%append( 'phi0', val )
 
 end subroutine set_prof_perp_gaussian
 
@@ -61,10 +67,11 @@ subroutine get_prof_perp_gaussian( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im
   integer, intent(in) :: mode
   real, intent(out) :: ar_re, ar_im, ai_re, ai_im
 
-  real :: w0, zr, curv, f_dist, gouy_shift, z_shift, z2, zr2, w, phase, r2, amp
+  real :: w0, zr, curv, f_dist, phi0, gouy_shift, z_shift, z2, zr2, w, phase, r2, amp
 
   call prof_pars%get( 'w0', w0 )
   call prof_pars%get( 'f_dist', f_dist )
+  call prof_pars%get( 'phi0', phi0 )
 
   if ( mode == 0 ) then
 
@@ -76,7 +83,7 @@ subroutine get_prof_perp_gaussian( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im
     curv = z_shift / ( z2 + zr2 )
     w = w0 * sqrt( 1.0 + z2 / zr2 )
     gouy_shift = atan2( z_shift, zr )
-    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * t
+    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * t + phi0 * pi / 180
     amp = w0 / w * exp(-r2 / (w*w))
 
     ar_re = amp * cos(phase)
@@ -112,6 +119,12 @@ subroutine set_prof_perp_laguerre( input, sect_name, prof_pars )
   call prof_pars%append( 'w0', rval )
   call input%get( trim(sect_name) // '.focal_distance', rval )
   call prof_pars%append( 'f_dist', rval )
+  if ( input%found( trim(sect_name) // '.phase' ) ) then
+    call input%get( trim(sect_name) // '.phase', rval )
+  else
+    rval = 0.0
+  endif
+  call prof_pars%append( 'phi0', rval )
   call input%get( trim(sect_name) // '.radial_index', ival )
   call prof_pars%append( 'radial_index', ival )
   call input%get( trim(sect_name) // '.phi_index', ival )
@@ -127,12 +140,14 @@ subroutine get_prof_perp_laguerre( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im
   integer, intent(in) :: mode
   real, intent(out) :: ar_re, ar_im, ai_re, ai_im
 
-  real :: w0, zr, curv, f_dist, gouy_shift, z_shift, z2, zr2, phase, w2, r2, r2_iw2, amp
+  real :: w0, zr, curv, f_dist, phi0, gouy_shift, z_shift, z2, zr2, phase, w2, r2, r2_iw2
+  real :: amp
   integer :: p, l
   real, parameter :: sqrt2 = 1.414213562373095
 
   call prof_pars%get( 'w0', w0 )
   call prof_pars%get( 'f_dist', f_dist )
+  call prof_pars%get( 'phi0', phi0 )
   call prof_pars%get( 'radial_index', p )
   call prof_pars%get( 'phi_index', l )
 
@@ -147,7 +162,7 @@ subroutine get_prof_perp_laguerre( r, z, t, k, k0, prof_pars, mode, ar_re, ar_im
     w2 = w0 * w0 * ( 1.0 + z2 / zr2 )
     r2_iw2 = r2 / w2
     gouy_shift = real( 1 + 2 * p + abs(l) ) * atan2( z_shift, zr )
-    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * t
+    phase = 0.5 * k * r2 * curv - gouy_shift - (k - k0) * t + phi0 * pi / 180
 
     ! This is the definition from Wikipedia
     ! amp = w0 / sqrt(w2) * exp(-r2_iw2) * ( sqrt2 * sqrt(r2_iw2) ) ** abs(l) &

--- a/source/laser/profile_laser_lib.f03
+++ b/source/laser/profile_laser_lib.f03
@@ -168,14 +168,15 @@ subroutine get_prof_perp_laguerre( r, z, k, k0, prof_pars, mode, ar_re, ar_im, a
 
     if ( mode == 0 ) then
       ar_re = amp * cos(phase)
-      ar_im = amp * sin(phase)
-      ai_re = 0.0
+      ar_im = 0.0
+      ai_re = -amp * sin(phase)
       ai_im = 0.0
     else
+      ! Notice the different order here for convenience
       ar_re =  0.5 * amp * cos(phase)
-      ar_im =  0.5 * amp * sin(phase)
-      ai_re = -ar_im
-      ai_im =  ar_re
+      ai_re = -0.5 * amp * sin(phase)
+      ar_im = -ai_re
+      ai_im = ar_re
     endif
 
   else

--- a/source/options_class.f03
+++ b/source/options_class.f03
@@ -88,11 +88,17 @@ subroutine init_options( this, input_file )
   call input_file%get( 'simulation.box.r(2)', max_val )
   this%dr = ( max_val - min_val ) / nr
 
-  call input_file%get( 'simulation.box.z(1)', min_val )
-  call input_file%get( 'simulation.box.z(2)', max_val )
+  if (.not. input_file%found( 'simulation.box.xi' )) then
+    call write_err( 'The "box.z" parameter in the simulation section of the input &
+                     &deck has now been changed to "box.xi". Additionally, &
+                     &the "time" and "dt" parameters have been changed to &
+                     &"length" and "dz".' )
+  endif
+  call input_file%get( 'simulation.box.xi(1)', min_val )
+  call input_file%get( 'simulation.box.xi(2)', max_val )
   this%dxi = ( max_val - min_val ) / nz
 
-  call input_file%get( 'simulation.dt', this%dt )
+  call input_file%get( 'simulation.dz', this%dt )
 
   ! the un-evenly distributed grid points among processors are accounted for
   local_size   = nr / num_procs_loc()

--- a/source/sim_beams_class.f03
+++ b/source/sim_beams_class.f03
@@ -85,7 +85,7 @@ subroutine init_sim_beams( this, input, opts )
 
   call write_dbg( cls_name, sname, cls_level, 'starts' )
 
-  call input%get( 'simulation.dt', dt )
+  call input%get( 'simulation.dz', dt )
   call input%get( 'simulation.read_restart', read_rst )
   ! call input%get( 'simulation.nbeams', n )
   call input%get( 'simulation.max_mode', max_mode )

--- a/source/sim_lasers_class.f03
+++ b/source/sim_lasers_class.f03
@@ -16,8 +16,6 @@ implicit none
 
 private
 
-public :: sim_lasers
-
 type, public :: sim_lasers
   
   class( field_laser ), dimension(:), pointer :: laser => null()

--- a/source/simulation_class.f03
+++ b/source/simulation_class.f03
@@ -142,8 +142,13 @@ subroutine init_simulation(this, input, opts)
   this%start2d = opts%get_noff(2) + 1
 
   call input%get( 'simulation.n0', n0 )
-  call input%get( 'simulation.time', time )
-  call input%get( 'simulation.dt', dt )
+  if ((.not. input%found( 'simulation.length' )) .or. &
+      (.not. input%found( 'simulation.dz' ))) then
+    call write_err( 'The "time" and "dt" parameters in the simulation section &
+                     &of the input deck have now been changed to "length" and "dz".' )
+  endif
+  call input%get( 'simulation.length', time )
+  call input%get( 'simulation.dz', dt )
   this%nstep3d = time/dt
   this%dt = dt
 

--- a/test/TEST_main2.f03
+++ b/test/TEST_main2.f03
@@ -91,8 +91,8 @@ call gp%new( pp, nr, nz )
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 call input%get('simulation.solver_precision',prec)
@@ -170,8 +170,8 @@ case (1)
    call pf3d2%p%new(input,2)
 end select
 
-call input%get('simulation.dt',dt)
-call input%get('simulation.time',tt)
+call input%get('simulation.dz',dt)
+call input%get('simulation.length',tt)
 nt = tt/dt
 call beam1%new(pp,pqb,gp,part_shape,pf3d1%p,-1.0,dt,7,st,so)
 call beam2%new(pp,pqb,gp,part_shape,pf3d2%p,-1.0,dt,7,st,so)

--- a/test/TEST_main3.f03
+++ b/test/TEST_main3.f03
@@ -91,8 +91,8 @@ call gp%new( pp, nr, nz )
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 call input%get('simulation.solver_precision',prec)
@@ -170,8 +170,8 @@ case (1)
    call pf3d2%p%new(input,2)
 end select
 
-call input%get('simulation.dt',dt)
-call input%get('simulation.time',tt)
+call input%get('simulation.dz',dt)
+call input%get('simulation.length',tt)
 nt = tt/dt
 call beam1%new(pp,pqb,gp,part_shape,pf3d1%p,-1.0,dt,7,st,so)
 call beam2%new(pp,pqb,gp,part_shape,pf3d2%p,-1.0,dt,7,st,so)

--- a/test/TEST_main4.f03
+++ b/test/TEST_main4.f03
@@ -86,8 +86,8 @@ call gp%new( pp, nr, nz )
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 call input%get('simulation.solver_precision',prec)
@@ -154,8 +154,8 @@ case (1)
    call pf3d%p%new(input,1)
 end select
 
-call input%get('simulation.dt',dt)
-call input%get('simulation.time',tt)
+call input%get('simulation.dz',dt)
+call input%get('simulation.length',tt)
 nt = tt/dt
 call beam%new(pp,pqb,gp,part_shape,pf3d%p,-1.0,dt,7,st,so)
 

--- a/test/TEST_main5.f03
+++ b/test/TEST_main5.f03
@@ -92,8 +92,8 @@ call gp%new( pp, nr, nz )
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 call input%get('simulation.solver_precision',prec)
@@ -186,8 +186,8 @@ case (1)
    call pf3d2%p%new(input,2)
 end select
 
-call input%get('simulation.dt',dt)
-call input%get('simulation.time',tt)
+call input%get('simulation.dz',dt)
+call input%get('simulation.length',tt)
 nt = tt/dt
 call beam1%new(pp,pqb,gp,part_shape,pf3d1%p,-1.0,dt,7,st,so)
 call beam2%new(pp,pqb,gp,part_shape,pf3d2%p,-1.0,dt,7,st,so)

--- a/test/TEST_species.f03
+++ b/test/TEST_species.f03
@@ -71,8 +71,8 @@ call gp%new( pp, nr, nz )
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 nrp = gp%get_ndp(1)
@@ -117,7 +117,7 @@ case (0)
    call pf3d%p%new(input,1)
 end select
 
-call input%get('simulation.dt',dt)
+call input%get('simulation.dz',dt)
 call qb%new(pp, gp, dr, dxi, num_modes, part_shape)
 call qb%as(0.0)
 call beam%new(pp,qb,gp,part_shape,pf3d%p,-1.0,dt,7)

--- a/test/TEST_wake.f03
+++ b/test/TEST_wake.f03
@@ -89,8 +89,8 @@ call gp%new( pp, nr, nz )
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 call input%get('simulation.solver_precision',prec)
@@ -152,8 +152,8 @@ case (0)
    call pf3d%p%new(input,1)
 end select
 
-call input%get('simulation.dt',dt)
-call input%get('simulation.time',tt)
+call input%get('simulation.dz',dt)
+call input%get('simulation.length',tt)
 nt = tt/dt
 call beam%new(pp,pqb,gp,part_shape,pf3d%p,-1.0,dt,7,st,so)
 

--- a/test/TEST_wake_new.f03
+++ b/test/TEST_wake_new.f03
@@ -82,8 +82,8 @@ call input%get('simulation.grid(2)',nz)
 call input%get('simulation.box.r(1)',rmin)
 call input%get('simulation.box.r(2)',rmax)
 dr = (rmax-rmin)/nr
-call input%get('simulation.box.z(1)',zmin)
-call input%get('simulation.box.z(2)',zmax)
+call input%get('simulation.box.xi(1)',zmin)
+call input%get('simulation.box.xi(2)',zmax)
 dxi = (zmax-zmin)/nz
 
 call gp%new( pp, nr, nz, dr, dxi )
@@ -152,8 +152,8 @@ case (1)
    call pf3d%p%new(input,1)
 end select
 
-call input%get('simulation.dt',dt)
-call input%get('simulation.time',tt)
+call input%get('simulation.dz',dt)
+call input%get('simulation.length',tt)
 nt = tt/dt
 call beam%new(pp,gp,num_modes,part_shape,pf3d%p,-1.0,dt,7,st,so)
 


### PR DESCRIPTION
The 0,0 mode gave incorrect results, inconsistent with the Gaussian pulse initialization.  Also fix higher-order modes as well.

I had to make some additional changes to structure in order to make this compile with the Intel 2024 ifx compiler.  Figure I would include those changes as well.

After speaking with @lifei07, it was determined that the code is written to take steps in `s = z`, not `s = t`.  The laser initialization routines were written as if `s = t`, so I changed these to be correct.  To avoid confusion for users, I also changed the input deck parameters `box.z`, `time`, and `dt` to `box.xi`, `length`, and `dz`, respectively.  However, no changes were made to variable names in the code, so this should be kept in mind to avoid confusion.

Finally, the chirp parameter has been changed so that instead of the first coefficient providing a linear chirp in `xi`, it provides a constant offset to the wavenumber.  The second chirp parameter now provides the linear chirp in `xi`.  This allows for the simulation of laser pulses that are close in wavenumber and develop a beat pattern in their intensity.

@lifei07, could you please take a look to make sure this is all good?  Thanks.

Also, @jacobpierce1, the astrl pulses have not been tested with this switch of z and t in the laser initialization section.  Maybe you could run some basic tests to make sure everything is still working as it should?  Thanks.